### PR TITLE
dns: add a wildcard record for blackfeminism

### DIFF
--- a/.github/workflows/terraform-zones-deploy.yml
+++ b/.github/workflows/terraform-zones-deploy.yml
@@ -8,8 +8,7 @@ on:
       - 'main'
     paths:
       - 'terraform/**'
-      - '.github/workflows/terraform-**'
-
+      - '.github/workflows/terraform-*.yml'
     
 jobs:
 

--- a/terraform/zones/zone.library.ucsb.edu.tf
+++ b/terraform/zones/zone.library.ucsb.edu.tf
@@ -1202,6 +1202,17 @@ zone_id = local.library-zone_id
   records = ["lb-haproxy-legacy-001.library.ucsb.edu."]
 }
 
+resource "aws_route53_record" "wildcard-blackfeminism-library-ucsb-edu-A" {
+  zone_id = local.library-zone_id
+  name    = "*.blackfeminism.library.ucsb.edu"
+  type    = "A"
+  alias {
+    name                   = adb450577d1c711e9acaa0a5f5c694d7
+    zone_id                = Z1H1FL5HABSF5
+    evaluate_target_health = true
+  }
+}
+
 resource "aws_route53_record" "dhcp-servers-1-library-ucsb-edu-A" {
 zone_id = local.library-zone_id
   name    = "dhcp-servers-1.library.ucsb.edu."


### PR DESCRIPTION
this is to test alias records to an existing ELB. the name and zone id provided
target the kubernetes cluster's elastic load balancer, introducing this record
should allow us to test that `something.blackfeminism.library.ucsb.edu` reaches
the cluster's ingress controller.

if this works, we can change the record for the top level to complete the DNS
changeover.