### PR TITLE
add aliasing to dld-eks cluster ELB

### DIFF
--- a/terraform/zones/zone.library.ucsb.edu.tf
+++ b/terraform/zones/zone.library.ucsb.edu.tf
@@ -2,6 +2,10 @@ locals {
   library-zone_id = aws_route53_zone.r53_zones["library-ucsb-edu"].zone_id
 }
 
+data "aws_elb" "dld-eks-nginx-ingress" {
+  name = "adb450577d1c711e9acaa0a5f5c694d7"
+}
+
 resource "aws_route53_record" "zabbix-library-ucsb-edu-CNAME" {
   zone_id = local.library-zone_id
   name    = "zabbix.library.ucsb.edu."
@@ -1168,6 +1172,17 @@ zone_id = local.library-zone_id
   type    = "CNAME"
   ttl     = "10800"
   records = ["lb-haproxy-legacy-001.library.ucsb.edu."]
+}
+
+resource "aws_route53_record" "wildcard-blackfeminism-library-ucsb-edu-A" {
+zone_id = local.library-zone_id
+  name    = "*.blackfeminism.library.ucsb.edu."
+  type    = "A"
+  alias {
+    name                   = data.aws_elb.dld-eks-nginx-ingress.dns_name
+    zone_id                = data.aws_elb.dld-eks-nginx-ingress.zone_id
+    evaluate_target_health = true
+  }
 }
 
 resource "aws_route53_record" "dhcp-servers-1-library-ucsb-edu-A" {


### PR DESCRIPTION
adds a data statement to import information about the
`adb450577d1c711e9acaa0a5f5c694d7` ELB, which directs its traffic to the
`dld-eks` Kubernetes cluster. alias records pointing to this ELB can be used to
route to the cluster's nginx ingress controller.

also adds a test record as a wildcard under
`blackfeminisim.library.ucsb.edu`. if this record works okay, it can be used as
a template for further alias records. this pattern can be used to inline several
hosted zones into this top level one, including:

  - cylinders.library.ucsb.edu
  - digital.library.ucsb.edu
  - dld.library.ucsb.edu
  - geodata.library.ucsb.edu
  - spotlight.library.ucsb.edu