### PR TITLE
add records for digital.library.ucsb.edu and wildcard 

### DIFF
--- a/terraform/zones/zone.library.ucsb.edu.tf
+++ b/terraform/zones/zone.library.ucsb.edu.tf
@@ -1188,6 +1188,28 @@ zone_id = local.library-zone_id
   }
 }
 
+resource "aws_route53_record" "digital-library-ucsb-edu-A" {
+zone_id = local.library-zone_id
+  name    = "digital.library.ucsb.edu."
+  type    = "A"
+  alias {
+    name                   = data.aws_elb.dld-eks-nginx-ingress.dns_name
+    zone_id                = data.aws_elb.dld-eks-nginx-ingress.zone_id
+    evaluate_target_health = true
+  }
+}
+
+resource "aws_route53_record" "wildcard-digital-library-ucsb-edu-A" {
+zone_id = local.library-zone_id
+  name    = "*.digital.library.ucsb.edu."
+  type    = "A"
+  alias {
+    name                   = data.aws_elb.dld-eks-nginx-ingress.dns_name
+    zone_id                = data.aws_elb.dld-eks-nginx-ingress.zone_id
+    evaluate_target_health = true
+  }
+}
+
 resource "aws_route53_record" "dhcp-servers-1-library-ucsb-edu-A" {
 zone_id = local.library-zone_id
   name    = "dhcp-servers-1.library.ucsb.edu."

--- a/terraform/zones/zone.library.ucsb.edu.tf
+++ b/terraform/zones/zone.library.ucsb.edu.tf
@@ -1166,12 +1166,15 @@ zone_id = local.library-zone_id
   records = ["lb-haproxy-legacy-001.library.ucsb.edu."]
 }
 
-resource "aws_route53_record" "blackfeminism-library-ucsb-edu-CNAME" {
+resource "aws_route53_record" "blackfeminism-library-ucsb-edu-A" {
 zone_id = local.library-zone_id
   name    = "blackfeminism.library.ucsb.edu."
-  type    = "CNAME"
-  ttl     = "10800"
-  records = ["lb-haproxy-legacy-001.library.ucsb.edu."]
+  type    = "A"
+  alias {
+    name                   = data.aws_elb.dld-eks-nginx-ingress.dns_name
+    zone_id                = data.aws_elb.dld-eks-nginx-ingress.zone_id
+    evaluate_target_health = true
+  }
 }
 
 resource "aws_route53_record" "wildcard-blackfeminism-library-ucsb-edu-A" {


### PR DESCRIPTION
the external hosted zone for these records was turned off in https://github.com/library-ucsb/iac-dns-route53/commit/b81f1cd3a0c9ca8dd710dd5ff537475e57c21bdf. this
killed traffic to these domains (oops!). this fixes it by inlining them to the
current hosted zone.