### PR TITLE
move AWS load balancer targets to the new DLD ingress controller

### DIFF
--- a/terraform/zones/zone.library.ucsb.edu.tf
+++ b/terraform/zones/zone.library.ucsb.edu.tf
@@ -6,6 +6,10 @@ data "aws_elb" "dld-eks-nginx-ingress" {
   name = "adb450577d1c711e9acaa0a5f5c694d7"
 }
 
+data "aws_elb" "dld-eks-ingress-nginx-v1" {
+  name = "a8058ed75a0774def8ba0fb05a90144d"
+}
+
 resource "aws_route53_record" "zabbix-library-ucsb-edu-CNAME" {
   zone_id = local.library-zone_id
   name    = "zabbix.library.ucsb.edu."
@@ -1123,8 +1127,8 @@ zone_id = local.library-zone_id
   name    = "blackfeminism.library.ucsb.edu."
   type    = "A"
   alias {
-    name                   = data.aws_elb.dld-eks-nginx-ingress.dns_name
-    zone_id                = data.aws_elb.dld-eks-nginx-ingress.zone_id
+    name                   = data.aws_elb.dld-eks-ingress-nginx-v1.dns_name
+    zone_id                = data.aws_elb.dld-eks-ingress-nginx-v1.zone_id
     evaluate_target_health = true
   }
 }
@@ -1134,8 +1138,8 @@ zone_id = local.library-zone_id
   name    = "*.blackfeminism.library.ucsb.edu."
   type    = "A"
   alias {
-    name                   = data.aws_elb.dld-eks-nginx-ingress.dns_name
-    zone_id                = data.aws_elb.dld-eks-nginx-ingress.zone_id
+    name                   = data.aws_elb.dld-eks-ingress-nginx-v1.dns_name
+    zone_id                = data.aws_elb.dld-eks-ingress-nginx-v1.zone_id
     evaluate_target_health = true
   }
 }
@@ -1145,8 +1149,8 @@ zone_id = local.library-zone_id
   name    = "digital.library.ucsb.edu."
   type    = "A"
   alias {
-    name                   = data.aws_elb.dld-eks-nginx-ingress.dns_name
-    zone_id                = data.aws_elb.dld-eks-nginx-ingress.zone_id
+    name                   = data.aws_elb.dld-eks-ingress-nginx-v1.dns_name
+    zone_id                = data.aws_elb.dld-eks-ingress-nginx-v1.zone_id
     evaluate_target_health = true
   }
 }
@@ -1156,8 +1160,8 @@ zone_id = local.library-zone_id
   name    = "*.digital.library.ucsb.edu."
   type    = "A"
   alias {
-    name                   = data.aws_elb.dld-eks-nginx-ingress.dns_name
-    zone_id                = data.aws_elb.dld-eks-nginx-ingress.zone_id
+    name                   = data.aws_elb.dld-eks-ingress-nginx-v1.dns_name
+    zone_id                = data.aws_elb.dld-eks-ingress-nginx-v1.zone_id
     evaluate_target_health = true
   }
 }


### PR DESCRIPTION
DLD had been running an older version of
https://kubernetes.github.io/ingress-nginx/, which supported both the v1beta Ingress API and the newer v1 API.

With the upgrade to Kubernetes v1.22, the v1beta API has been removed, which is causing that ingress controller deployment to fail when assigning new ingresses (it's trying to list all v1beta ingresses, but the resource definition doesn't exist).

We have a newer Ingress Controller in place which is working, running version 1.x of the controller application. The new load balancer targeted here is the one that points to the new ingress controller.