### PR TITLE
Redirects for legacy websites

### DIFF
--- a/terraform/zones/zone.library.ucsb.edu.tf
+++ b/terraform/zones/zone.library.ucsb.edu.tf
@@ -14,6 +14,14 @@ zone_id = local.library-zone_id
   records = ["23.185.0.4"]
 }
 
+resource "aws_route53_record" "wildcard-library-ucsb-edu-cloudfront-CNAME" {
+zone_id = local.library-zone_id
+  name    = "_1a4ae0fdc09a2579501cceb77eff2835.library.ucsb.edu."
+  type    = "CNAME"
+  ttl     = "300"
+  records = ["_cecf8d1aea6148c752cdaeb6d9e6e16a.acm-validations.aws."]
+}
+
 resource "aws_route53_record" "winshares-library-ucsb-edu-A" {
 zone_id = local.library-zone_id
   name    = "winshares.library.ucsb.edu."

--- a/terraform/zones/zone.library.ucsb.edu.tf
+++ b/terraform/zones/zone.library.ucsb.edu.tf
@@ -35,7 +35,7 @@ zone_id = local.library-zone_id
   name    = "we-remember-them.library.ucsb.edu."
   type    = "CNAME"
   ttl     = "10800"
-  records = ["lb-haproxy-legacy-001.library.ucsb.edu."]
+  records = ["dfxvhm9lq0zwe.cloudfront.net."]
 }
 
 resource "aws_route53_record" "we-remember-them-test-library-ucsb-edu-CNAME" {

--- a/terraform/zones/zone.library.ucsb.edu.tf
+++ b/terraform/zones/zone.library.ucsb.edu.tf
@@ -91,7 +91,7 @@ zone_id = local.library-zone_id
   name    = "ucsbreads.library.ucsb.edu."
   type    = "CNAME"
   ttl     = "10800"
-  records = ["lb-haproxy-legacy-001.library.ucsb.edu."]
+  records = ["dfxvhm9lq0zwe.cloudfront.net."]
 }
 
 resource "aws_route53_record" "ucsbjenkins-library-ucsb-edu-CNAME" {

--- a/terraform/zones/zone.library.ucsb.edu.tf
+++ b/terraform/zones/zone.library.ucsb.edu.tf
@@ -38,14 +38,6 @@ zone_id = local.library-zone_id
   records = ["dfxvhm9lq0zwe.cloudfront.net."]
 }
 
-resource "aws_route53_record" "we-remember-them-test-library-ucsb-edu-CNAME" {
-zone_id = local.library-zone_id
-  name    = "we-remember-them-test.library.ucsb.edu."
-  type    = "CNAME"
-  ttl     = "20"
-  records = ["dfxvhm9lq0zwe.cloudfront.net."]
-}
-
 resource "aws_route53_record" "vpn-library-ucsb-edu-CNAME" {
 zone_id = local.library-zone_id
   name    = "vpn.library.ucsb.edu."

--- a/terraform/zones/zone.library.ucsb.edu.tf
+++ b/terraform/zones/zone.library.ucsb.edu.tf
@@ -38,6 +38,14 @@ zone_id = local.library-zone_id
   records = ["dfxvhm9lq0zwe.cloudfront.net."]
 }
 
+resource "aws_route53_record" "we-remember-them-cloudfront-CNAME" {
+zone_id = local.library-zone_id
+  name    = "_15a93d1bd59ecfa0a90c875c62475494.we-remember-them.library.ucsb.edu."
+  type    = "CNAME"
+  ttl     = "300"
+  records = ["_7933f0008a7edafc56a5ad719968f404.kdbplsmznr.acm-validations.aws."]
+}
+
 resource "aws_route53_record" "vpn-library-ucsb-edu-CNAME" {
 zone_id = local.library-zone_id
   name    = "vpn.library.ucsb.edu."

--- a/terraform/zones/zone.library.ucsb.edu.tf
+++ b/terraform/zones/zone.library.ucsb.edu.tf
@@ -46,14 +46,6 @@ zone_id = local.library-zone_id
   records = ["dfxvhm9lq0zwe.cloudfront.net."]
 }
 
-resource "aws_route53_record" "we-remember-them-cloudfront-CNAME" {
-zone_id = local.library-zone_id
-  name    = "_15a93d1bd59ecfa0a90c875c62475494.we-remember-them.library.ucsb.edu."
-  type    = "CNAME"
-  ttl     = "300"
-  records = ["_7933f0008a7edafc56a5ad719968f404.kdbplsmznr.acm-validations.aws."]
-}
-
 resource "aws_route53_record" "vpn-library-ucsb-edu-CNAME" {
 zone_id = local.library-zone_id
   name    = "vpn.library.ucsb.edu."


### PR DESCRIPTION
Changes location of we-remember-them to a cloudfront distribution with an s3 endpoint to redirect visitors to wayback machine.

This required creating the following:
1. s3 bucket
2. cloudfront distribution
3. ssl cert in us-east-1/ACM
4. CNAME record in Route53 for cert validation and auto renewal

