### PR TITLE
Migrate sites to cloudfront/s3

### DIFF
--- a/terraform/zones/zone.alexandria.ucsb.edu.tf
+++ b/terraform/zones/zone.alexandria.ucsb.edu.tf
@@ -26,13 +26,12 @@ resource "aws_route53_record" "piru-alexandria-ucsb-edu-CNAME" {
   records = ["lb-haproxy-legacy-001.library.ucsb.edu."]
 }
 
-#  Legacy ADL through HA-HAproxy pair
 resource "aws_route53_record" "legacy-alexandria-ucsb-edu-CNAME" {
   zone_id = local.alex-zone_id
   name    = "legacy.alexandria.ucsb.edu."
   type    = "CNAME"
-  ttl     = "10800"
-  records = ["haproxy.library.ucsb.edu."]
+  ttl     = "300"
+  records = ["d1xax2soipw9h8.cloudfront.net."]
 }
 
 resource "aws_route53_record" "legacy-alexandria-ucsb-edu-cloudfront-CNAME" {

--- a/terraform/zones/zone.alexandria.ucsb.edu.tf
+++ b/terraform/zones/zone.alexandria.ucsb.edu.tf
@@ -35,6 +35,14 @@ resource "aws_route53_record" "legacy-alexandria-ucsb-edu-CNAME" {
   records = ["haproxy.library.ucsb.edu."]
 }
 
+resource "aws_route53_record" "legacy-alexandria-ucsb-edu-cloudfront-CNAME" {
+  zone_id = local.alex-zone_id
+  name    = "_f5146d47cecdfaa13d510c8d8b0e8bf5.legacy.alexandria.ucsb.edu."
+  type    = "CNAME"
+  ttl     = "10800"
+  records = ["_633c924c0d54b711422966e745e0f692.kdbplsmznr.acm-validations.aws."]
+}
+
 resource "aws_route53_record" "collections-alexandria-ucsb-edu-CNAME" {
   zone_id = local.alex-zone_id
   name    = "collections.alexandria.ucsb.edu."


### PR DESCRIPTION
These changes will replace haproxy with cloudfront and s3 to handle redirects to the library website.

Uses new ssl cert (generated in us-east-1) for https traffic.