### PR TITLE
removing NS1 and NS2

### DIFF
--- a/terraform/zones/zone.87.111.128.in-addr.arpa.tf
+++ b/terraform/zones/zone.87.111.128.in-addr.arpa.tf
@@ -106,14 +106,6 @@ resource "aws_route53_record" "_46-87-111-128-in-addr-arpa-PTR" {
   records = ["kms.library.ucsb.edu."]
 }
 
-resource "aws_route53_record" "_44-87-111-128-in-addr-arpa-PTR" {
-  zone_id = local.rev87-zone_id
-  name    = "44.87.111.128.in-addr.arpa."
-  type    = "PTR"
-  ttl     = "10800"
-  records = ["ns2.library.ucsb.edu."]
-}
-
 resource "aws_route53_record" "_42-87-111-128-in-addr-arpa-PTR" {
   zone_id = local.rev87-zone_id
   name    = "42.87.111.128.in-addr.arpa."
@@ -152,14 +144,6 @@ resource "aws_route53_record" "_33-87-111-128-in-addr-arpa-PTR" {
   type    = "PTR"
   ttl     = "10800"
   records = ["proxy-v.library.ucsb.edu."]
-}
-
-resource "aws_route53_record" "_30-87-111-128-in-addr-arpa-PTR" {
-  zone_id = local.rev87-zone_id
-  name    = "30.87.111.128.in-addr.arpa."
-  type    = "PTR"
-  ttl     = "10800"
-  records = ["ns1.library.ucsb.edu."]
 }
 
 resource "aws_route53_record" "_27-87-111-128-in-addr-arpa-PTR" {

--- a/terraform/zones/zone.library.ucsb.edu.tf
+++ b/terraform/zones/zone.library.ucsb.edu.tf
@@ -358,22 +358,6 @@ zone_id = local.library-zone_id
   records = ["128.111.87.183"]
 }
 
-resource "aws_route53_record" "ns2-library-ucsb-edu-A" {
-zone_id = local.library-zone_id
-  name    = "ns2.library.ucsb.edu."
-  type    = "A"
-  ttl     = "10800"
-  records = ["128.111.87.44"]
-}
-
-resource "aws_route53_record" "ns1-library-ucsb-edu-A" {
-zone_id = local.library-zone_id
-  name    = "ns1.library.ucsb.edu."
-  type    = "A"
-  ttl     = "10800"
-  records = ["128.111.87.30"]
-}
-
 resource "aws_route53_record" "nico-library-ucsb-edu-CNAME" {
 zone_id = local.library-zone_id
   name    = "nico.library.ucsb.edu."


### PR DESCRIPTION
For https://ucsb-atlas.atlassian.net/browse/OPS-3796. Removed from WinDNS already. Plan action already run and passed. 