### PR TITLE
Mv arc lobero truesound to lb haproxy legacy 001

### DIFF
--- a/terraform/zones/zone.library.ucsb.edu.tf
+++ b/terraform/zones/zone.library.ucsb.edu.tf
@@ -131,7 +131,7 @@ zone_id = local.library-zone_id
   name    = "truesound.library.ucsb.edu."
   type    = "CNAME"
   ttl     = "10800"
-  records = ["haproxy.library.ucsb.edu."]
+  records = ["lb-haproxy-legacy-001.library.ucsb.edu."]
 }
 
 resource "aws_route53_record" "tl-library-ucsb-edu-A" {
@@ -499,7 +499,7 @@ zone_id = local.library-zone_id
   name    = "lobero.library.ucsb.edu."
   type    = "CNAME"
   ttl     = "10800"
-  records = ["haproxy.library.ucsb.edu."]
+  records = ["lb-haproxy-legacy-001.library.ucsb.edu."]
 }
 
 resource "aws_route53_record" "license-2019-library-ucsb-edu-A" {
@@ -1151,7 +1151,7 @@ zone_id = local.library-zone_id
   name    = "arc.library.ucsb.edu."
   type    = "CNAME"
   ttl     = "10800"
-  records = ["haproxy.library.ucsb.edu."]
+  records = ["lb-haproxy-legacy-001.library.ucsb.edu."]
 }
 
 resource "aws_route53_record" "alma-sftp-library-ucsb-edu-CNAME" {

--- a/terraform/zones/zone.library.ucsb.edu.tf
+++ b/terraform/zones/zone.library.ucsb.edu.tf
@@ -118,14 +118,6 @@ zone_id = local.library-zone_id
   records = ["128.111.87.247"]
 }
 
-resource "aws_route53_record" "truesoundstage-library-ucsb-edu-CNAME" {
-zone_id = local.library-zone_id
-  name    = "truesoundstage.library.ucsb.edu."
-  type    = "CNAME"
-  ttl     = "10800"
-  records = ["haproxy.library.ucsb.edu."]
-}
-
 resource "aws_route53_record" "truesound-library-ucsb-edu-CNAME" {
 zone_id = local.library-zone_id
   name    = "truesound.library.ucsb.edu."
@@ -484,14 +476,6 @@ zone_id = local.library-zone_id
   type    = "CNAME"
   ttl     = "10800"
   records = ["splunk-352.library.ucsb.edu."]
-}
-
-resource "aws_route53_record" "loberostage-library-ucsb-edu-CNAME" {
-zone_id = local.library-zone_id
-  name    = "loberostage.library.ucsb.edu."
-  type    = "CNAME"
-  ttl     = "10800"
-  records = ["haproxy.library.ucsb.edu."]
 }
 
 resource "aws_route53_record" "lobero-library-ucsb-edu-CNAME" {
@@ -1136,14 +1120,6 @@ zone_id = local.library-zone_id
   type    = "A"
   ttl     = "10800"
   records = ["128.111.87.115"]
-}
-
-resource "aws_route53_record" "arcstage-library-ucsb-edu-CNAME" {
-zone_id = local.library-zone_id
-  name    = "arcstage.library.ucsb.edu."
-  type    = "CNAME"
-  ttl     = "10800"
-  records = ["haproxy.library.ucsb.edu."]
 }
 
 resource "aws_route53_record" "arc-library-ucsb-edu-CNAME" {


### PR DESCRIPTION
Two commits.  The first changes the websites to point to lb-haproxy-legacy-001.  The second removes the entries for the staging sites for the respective websites, as their entries no longer exist in haproxy.library.ucsb.edu.  Initialize and Plan has executed successfully.