### PR TITLE
Mv alexandria to lb haproxy legacy 001

### DIFF
--- a/terraform/zones/zone.alexandria.ucsb.edu.tf
+++ b/terraform/zones/zone.alexandria.ucsb.edu.tf
@@ -7,7 +7,7 @@ resource "aws_route53_record" "www-alexandria-ucsb-edu-CNAME" {
   name    = "www.alexandria.ucsb.edu."
   type    = "CNAME"
   ttl     = "10800"
-  records = ["haproxyt.library.ucsb.edu."]
+  records = ["lb-haproxy-legacy-001.library.ucsb.edu."]
 }
 
 resource "aws_route53_record" "ucftp-alexandria-ucsb-edu-CNAME" {
@@ -66,12 +66,12 @@ resource "aws_route53_record" "alexandria-ucsb-edu-MX" {
   records = ["1 aspmx.l.google.com.", "5 alt1.aspmx.l.google.com.", "5 alt2.aspmx.l.google.com.", "10 aspmx2.googlemail.com.", "10 aspmx3.googlemail.com."]
 }
 
-resource "aws_route53_record" "alexandria-ucsb-edu-A" {
+resource "aws_route53_record" "alexandria-ucsb-edu-CNAME" {
   zone_id = local.alex-zone_id
   name    = "alexandria.ucsb.edu."
-  type    = "A"
+  type    = "CNAME"
   ttl     = "10800"
-  records = ["128.111.87.12"]
+  records = ["lb-haproxy-legacy-001.library.ucsb.edu"]
 }
 
 #  All *.legacy.library.ucsb.edu requests

--- a/terraform/zones/zone.alexandria.ucsb.edu.tf
+++ b/terraform/zones/zone.alexandria.ucsb.edu.tf
@@ -71,7 +71,7 @@ resource "aws_route53_record" "alexandria-ucsb-edu-CNAME" {
   name    = "alexandria.ucsb.edu."
   type    = "CNAME"
   ttl     = "10800"
-  records = ["lb-haproxy-legacy-001.library.ucsb.edu"]
+  records = ["lb-haproxy-legacy-001.library.ucsb.edu."]
 }
 
 #  All *.legacy.library.ucsb.edu requests


### PR DESCRIPTION
Changing the CNAME record for www.alexandria.ucsb.edu to point to lb-haproxy-legacy-001.library.ucsb.edu.  Changing the A record for alexandria.ucsb.edu to a CNAME to point to lb-haproxy-legacy-001.library.ucsb.edu.

A second commit was made to add a trailing "." for the CNAME for alexandria.ucsb.edu.

Initialize and Plan has successfully executed.