### PR TITLE
Revert "Mv alexandria to lb haproxy legacy 001"

### DIFF
--- a/terraform/zones/zone.alexandria.ucsb.edu.tf
+++ b/terraform/zones/zone.alexandria.ucsb.edu.tf
@@ -7,7 +7,7 @@ resource "aws_route53_record" "www-alexandria-ucsb-edu-CNAME" {
   name    = "www.alexandria.ucsb.edu."
   type    = "CNAME"
   ttl     = "10800"
-  records = ["lb-haproxy-legacy-001.library.ucsb.edu."]
+  records = ["haproxyt.library.ucsb.edu."]
 }
 
 resource "aws_route53_record" "ucftp-alexandria-ucsb-edu-CNAME" {
@@ -66,12 +66,12 @@ resource "aws_route53_record" "alexandria-ucsb-edu-MX" {
   records = ["1 aspmx.l.google.com.", "5 alt1.aspmx.l.google.com.", "5 alt2.aspmx.l.google.com.", "10 aspmx2.googlemail.com.", "10 aspmx3.googlemail.com."]
 }
 
-resource "aws_route53_record" "alexandria-ucsb-edu-CNAME" {
+resource "aws_route53_record" "alexandria-ucsb-edu-A" {
   zone_id = local.alex-zone_id
   name    = "alexandria.ucsb.edu."
-  type    = "CNAME"
+  type    = "A"
   ttl     = "10800"
-  records = ["lb-haproxy-legacy-001.library.ucsb.edu."]
+  records = ["128.111.87.12"]
 }
 
 #  All *.legacy.library.ucsb.edu requests


### PR DESCRIPTION
Reverts library-ucsb/iac-dns-route53#65

Action failed.  The CNAME record for www.alexandria.ucsb.edu was created, but the CNAME from A Record change for alexandria.ucsb.edu is missing.  We will revert the changes and review the error noted in the Action log.