### PR TITLE
Update zone.alexandria.ucsb.edu.tf

### DIFF
--- a/terraform/zones/zone.alexandria.ucsb.edu.tf
+++ b/terraform/zones/zone.alexandria.ucsb.edu.tf
@@ -7,7 +7,7 @@ resource "aws_route53_record" "www-alexandria-ucsb-edu-CNAME" {
   name    = "www.alexandria.ucsb.edu."
   type    = "CNAME"
   ttl     = "10800"
-  records = ["haproxyt.library.ucsb.edu."]
+  records = ["lb-haproxy-legacy-001.library.ucsb.edu."]
 }
 
 resource "aws_route53_record" "ucftp-alexandria-ucsb-edu-CNAME" {
@@ -71,7 +71,7 @@ resource "aws_route53_record" "alexandria-ucsb-edu-A" {
   name    = "alexandria.ucsb.edu."
   type    = "A"
   ttl     = "10800"
-  records = ["128.111.87.12"]
+  records = ["128.111.87.17"]
 }
 
 #  All *.legacy.library.ucsb.edu requests


### PR DESCRIPTION
Changed alexandria.ucsb.edu A record to point to IP 128.111.87.17 (lb-haproxy-legacy-001).  Unfortunately this must be an A record, as there can be no CNAME that is the same as a SOA record.  Changed www.alexandria.ucsb.edu CNAME to point to lb-haproxy-legacy-001.

Init & Plan action has succeeded.