### PR TITLE
removing forward and reverse entries for libwsus

### DIFF
--- a/terraform/zones/zone.87.111.128.in-addr.arpa.tf
+++ b/terraform/zones/zone.87.111.128.in-addr.arpa.tf
@@ -50,14 +50,6 @@ resource "aws_route53_record" "_71-87-111-128-in-addr-arpa-PTR" {
   records = ["openvpn2019.library.ucsb.edu."]
 }
 
-resource "aws_route53_record" "_60-87-111-128-in-addr-arpa-PTR" {
-  zone_id = local.rev87-zone_id
-  name    = "60.87.111.128.in-addr.arpa."
-  type    = "PTR"
-  ttl     = "10800"
-  records = ["libwsus.library.ucsb.edu."]
-}
-
 resource "aws_route53_record" "_59-87-111-128-in-addr-arpa-PTR" {
   zone_id = local.rev87-zone_id
   name    = "59.87.111.128.in-addr.arpa."

--- a/terraform/zones/zone.library.ucsb.edu.tf
+++ b/terraform/zones/zone.library.ucsb.edu.tf
@@ -470,14 +470,6 @@ zone_id = local.library-zone_id
   records = ["128.111.87.237"]
 }
 
-resource "aws_route53_record" "libwsus-library-ucsb-edu-A" {
-zone_id = local.library-zone_id
-  name    = "libwsus.library.ucsb.edu."
-  type    = "A"
-  ttl     = "10800"
-  records = ["128.111.87.60"]
-}
-
 resource "aws_route53_record" "library-ucsb-edu-TXT" {
 zone_id = local.library-zone_id
   name    = "library.ucsb.edu."


### PR DESCRIPTION
The libwsus server is decommissioned. We no longer need the A or PTR records. Plan action has successfully completed. 
https://ucsb-atlas.atlassian.net/browse/OPS-3804