### PR TITLE
add new AWS NLB for nginx ingress migration

### DIFF
--- a/terraform/zones/zone.library.ucsb.edu.tf
+++ b/terraform/zones/zone.library.ucsb.edu.tf
@@ -7,7 +7,7 @@ data "aws_elb" "dld-eks-ingress-nginx-v1" {
 }
 
 data "aws_lb" "dld-eks-ingress-nginx-v2" {
-  name = "af38c76df6b0d473c9a2f5158c4362e1"
+  name = "ab9bed8d4ef234d5ebac20d3b06b8c3e"
 }
 
 resource "aws_route53_record" "www-library-ucsb-edu-A" {

--- a/terraform/zones/zone.library.ucsb.edu.tf
+++ b/terraform/zones/zone.library.ucsb.edu.tf
@@ -6,6 +6,10 @@ data "aws_elb" "dld-eks-ingress-nginx-v1" {
   name = "a8058ed75a0774def8ba0fb05a90144d"
 }
 
+data "aws_lb" "dld-eks-ingress-nginx-v2" {
+  name = "af38c76df6b0d473c9a2f5158c4362e1"
+}
+
 resource "aws_route53_record" "www-library-ucsb-edu-A" {
 zone_id = local.library-zone_id
   name    = "www.library.ucsb.edu."
@@ -473,7 +477,7 @@ zone_id = local.library-zone_id
     evaluate_target_health = true
   }
 }
-  
+
 resource "aws_route53_record" "license-2019-library-ucsb-edu-A" {
 zone_id = local.library-zone_id
   name    = "license-2019.library.ucsb.edu."
@@ -842,8 +846,8 @@ zone_id = local.library-zone_id
   name    = "*.blackfeminism.library.ucsb.edu."
   type    = "A"
   alias {
-    name                   = data.aws_elb.dld-eks-ingress-nginx-v1.dns_name
-    zone_id                = data.aws_elb.dld-eks-ingress-nginx-v1.zone_id
+    name                   = data.aws_elb.dld-eks-ingress-nginx-v2.dns_name
+    zone_id                = data.aws_elb.dld-eks-ingress-nginx-v2.zone_id
     evaluate_target_health = true
   }
 }


### PR DESCRIPTION
i created this NLB by provisioning a new v1 Service with metadata annotation: `service.beta.kubernetes.io/aws-load-balancer-type: nlb`

this is already routing to the nginx
controller:
ab9bed8d4ef234d5ebac20d3b06b8c3e-43bf1be31605f562.elb.us-west-2.amazonaws.com gives 404 from the nginx instance running in cluster.

we should be able to migrate all the traffic off the Classic Load Balancer by moving the various DNS records currently pointing to dld-eks-ingress-nginx-v1. rather than doing this all at once, i'd like to test with this wildcard record, ensure it routes as expected, and then move the remainder.

related to https://gitlab.com/ucsb-library/cloud-infra/-/issues/69