### PR TITLE
update nginx-ingress records to point to the new NLB

### DIFF
--- a/terraform/zones/zone.library.ucsb.edu.tf
+++ b/terraform/zones/zone.library.ucsb.edu.tf
@@ -2,10 +2,6 @@ locals {
   library-zone_id = aws_route53_zone.r53_zones["library-ucsb-edu"].zone_id
 }
 
-data "aws_elb" "dld-eks-ingress-nginx-v1" {
-  name = "a8058ed75a0774def8ba0fb05a90144d"
-}
-
 data "aws_lb" "dld-eks-ingress-nginx-v2" {
   name = "ab9bed8d4ef234d5ebac20d3b06b8c3e"
 }

--- a/terraform/zones/zone.library.ucsb.edu.tf
+++ b/terraform/zones/zone.library.ucsb.edu.tf
@@ -119,8 +119,8 @@ zone_id = local.library-zone_id
   name    = "truesound.library.ucsb.edu."
   type    = "A"
   alias {
-    name                   = data.aws_elb.dld-eks-ingress-nginx-v1.dns_name
-    zone_id                = data.aws_elb.dld-eks-ingress-nginx-v1.zone_id
+    name                   = data.aws_lb.dld-eks-ingress-nginx-v2.dns_name
+    zone_id                = data.aws_lb.dld-eks-ingress-nginx-v2.zone_id
     evaluate_target_health = true
   }
 }
@@ -130,8 +130,8 @@ zone_id = local.library-zone_id
   name    = "*.truesound.library.ucsb.edu."
   type    = "A"
   alias {
-    name                   = data.aws_elb.dld-eks-ingress-nginx-v1.dns_name
-    zone_id                = data.aws_elb.dld-eks-ingress-nginx-v1.zone_id
+    name                   = data.aws_lb.dld-eks-ingress-nginx-v2.dns_name
+    zone_id                = data.aws_lb.dld-eks-ingress-nginx-v2.zone_id
     evaluate_target_health = true
   }
 }
@@ -461,8 +461,8 @@ zone_id = local.library-zone_id
   name    = "lobero.library.ucsb.edu."
   type    = "A"
   alias {
-    name                   = data.aws_elb.dld-eks-ingress-nginx-v1.dns_name
-    zone_id                = data.aws_elb.dld-eks-ingress-nginx-v1.zone_id
+    name                   = data.aws_lb.dld-eks-ingress-nginx-v2.dns_name
+    zone_id                = data.aws_lb.dld-eks-ingress-nginx-v2.zone_id
     evaluate_target_health = true
   }
 }
@@ -472,8 +472,8 @@ zone_id = local.library-zone_id
   name    = "*.lobero.library.ucsb.edu."
   type    = "A"
   alias {
-    name                   = data.aws_elb.dld-eks-ingress-nginx-v1.dns_name
-    zone_id                = data.aws_elb.dld-eks-ingress-nginx-v1.zone_id
+    name                   = data.aws_lb.dld-eks-ingress-nginx-v2.dns_name
+    zone_id                = data.aws_lb.dld-eks-ingress-nginx-v2.zone_id
     evaluate_target_health = true
   }
 }
@@ -835,8 +835,8 @@ zone_id = local.library-zone_id
   name    = "blackfeminism.library.ucsb.edu."
   type    = "A"
   alias {
-    name                   = data.aws_elb.dld-eks-ingress-nginx-v1.dns_name
-    zone_id                = data.aws_elb.dld-eks-ingress-nginx-v1.zone_id
+    name                   = data.aws_lb.dld-eks-ingress-nginx-v2.dns_name
+    zone_id                = data.aws_lb.dld-eks-ingress-nginx-v2.zone_id
     evaluate_target_health = true
   }
 }
@@ -857,8 +857,8 @@ zone_id = local.library-zone_id
   name    = "cylinders.library.ucsb.edu."
   type    = "A"
   alias {
-    name                   = data.aws_elb.dld-eks-ingress-nginx-v1.dns_name
-    zone_id                = data.aws_elb.dld-eks-ingress-nginx-v1.zone_id
+    name                   = data.aws_lb.dld-eks-ingress-nginx-v2.dns_name
+    zone_id                = data.aws_lb.dld-eks-ingress-nginx-v2.zone_id
     evaluate_target_health = true
   }
 }
@@ -868,8 +868,8 @@ zone_id = local.library-zone_id
   name    = "*.cylinders.library.ucsb.edu."
   type    = "A"
   alias {
-    name                   = data.aws_elb.dld-eks-ingress-nginx-v1.dns_name
-    zone_id                = data.aws_elb.dld-eks-ingress-nginx-v1.zone_id
+    name                   = data.aws_lb.dld-eks-ingress-nginx-v2.dns_name
+    zone_id                = data.aws_lb.dld-eks-ingress-nginx-v2.zone_id
     evaluate_target_health = true
   }
 }
@@ -879,8 +879,8 @@ zone_id = local.library-zone_id
   name    = "digital.library.ucsb.edu."
   type    = "A"
   alias {
-    name                   = data.aws_elb.dld-eks-ingress-nginx-v1.dns_name
-    zone_id                = data.aws_elb.dld-eks-ingress-nginx-v1.zone_id
+    name                   = data.aws_lb.dld-eks-ingress-nginx-v2.dns_name
+    zone_id                = data.aws_lb.dld-eks-ingress-nginx-v2.zone_id
     evaluate_target_health = true
   }
 }
@@ -890,8 +890,8 @@ zone_id = local.library-zone_id
   name    = "*.digital.library.ucsb.edu."
   type    = "A"
   alias {
-    name                   = data.aws_elb.dld-eks-ingress-nginx-v1.dns_name
-    zone_id                = data.aws_elb.dld-eks-ingress-nginx-v1.zone_id
+    name                   = data.aws_lb.dld-eks-ingress-nginx-v2.dns_name
+    zone_id                = data.aws_lb.dld-eks-ingress-nginx-v2.zone_id
     evaluate_target_health = true
   }
 }
@@ -901,8 +901,8 @@ zone_id = local.library-zone_id
   name    = "geodata.library.ucsb.edu."
   type    = "A"
   alias {
-    name                   = data.aws_elb.dld-eks-ingress-nginx-v1.dns_name
-    zone_id                = data.aws_elb.dld-eks-ingress-nginx-v1.zone_id
+    name                   = data.aws_lb.dld-eks-ingress-nginx-v2.dns_name
+    zone_id                = data.aws_lb.dld-eks-ingress-nginx-v2.zone_id
     evaluate_target_health = true
   }
 }
@@ -912,8 +912,8 @@ zone_id = local.library-zone_id
   name    = "*.geodata.library.ucsb.edu."
   type    = "A"
   alias {
-    name                   = data.aws_elb.dld-eks-ingress-nginx-v1.dns_name
-    zone_id                = data.aws_elb.dld-eks-ingress-nginx-v1.zone_id
+    name                   = data.aws_lb.dld-eks-ingress-nginx-v2.dns_name
+    zone_id                = data.aws_lb.dld-eks-ingress-nginx-v2.zone_id
     evaluate_target_health = true
   }
 }
@@ -923,8 +923,8 @@ zone_id = local.library-zone_id
   name    = "spotlight.library.ucsb.edu."
   type    = "A"
   alias {
-    name                   = data.aws_elb.dld-eks-ingress-nginx-v1.dns_name
-    zone_id                = data.aws_elb.dld-eks-ingress-nginx-v1.zone_id
+    name                   = data.aws_lb.dld-eks-ingress-nginx-v2.dns_name
+    zone_id                = data.aws_lb.dld-eks-ingress-nginx-v2.zone_id
     evaluate_target_health = true
   }
 }
@@ -934,8 +934,8 @@ zone_id = local.library-zone_id
   name    = "*.spotlight.library.ucsb.edu."
   type    = "A"
   alias {
-    name                   = data.aws_elb.dld-eks-ingress-nginx-v1.dns_name
-    zone_id                = data.aws_elb.dld-eks-ingress-nginx-v1.zone_id
+    name                   = data.aws_lb.dld-eks-ingress-nginx-v2.dns_name
+    zone_id                = data.aws_lb.dld-eks-ingress-nginx-v2.zone_id
     evaluate_target_health = true
   }
 }
@@ -945,8 +945,8 @@ zone_id = local.library-zone_id
   name    = "spotlight-stage.library.ucsb.edu."
   type    = "A"
   alias {
-    name                   = data.aws_elb.dld-eks-ingress-nginx-v1.dns_name
-    zone_id                = data.aws_elb.dld-eks-ingress-nginx-v1.zone_id
+    name                   = data.aws_lb.dld-eks-ingress-nginx-v2.dns_name
+    zone_id                = data.aws_lb.dld-eks-ingress-nginx-v2.zone_id
     evaluate_target_health = true
   }
 }
@@ -956,8 +956,8 @@ zone_id = local.library-zone_id
   name    = "*.spotlight-stage.library.ucsb.edu."
   type    = "A"
   alias {
-    name                   = data.aws_elb.dld-eks-ingress-nginx-v1.dns_name
-    zone_id                = data.aws_elb.dld-eks-ingress-nginx-v1.zone_id
+    name                   = data.aws_lb.dld-eks-ingress-nginx-v2.dns_name
+    zone_id                = data.aws_lb.dld-eks-ingress-nginx-v2.zone_id
     evaluate_target_health = true
   }
 }
@@ -1031,8 +1031,8 @@ zone_id = local.library-zone_id
   name    = "arc.library.ucsb.edu."
   type    = "A"
   alias {
-    name                   = data.aws_elb.dld-eks-ingress-nginx-v1.dns_name
-    zone_id                = data.aws_elb.dld-eks-ingress-nginx-v1.zone_id
+    name                   = data.aws_lb.dld-eks-ingress-nginx-v2.dns_name
+    zone_id                = data.aws_lb.dld-eks-ingress-nginx-v2.zone_id
     evaluate_target_health = true
   }
 }
@@ -1042,8 +1042,8 @@ zone_id = local.library-zone_id
   name    = "*.arc.library.ucsb.edu."
   type    = "A"
   alias {
-    name                   = data.aws_elb.dld-eks-ingress-nginx-v1.dns_name
-    zone_id                = data.aws_elb.dld-eks-ingress-nginx-v1.zone_id
+    name                   = data.aws_lb.dld-eks-ingress-nginx-v2.dns_name
+    zone_id                = data.aws_lb.dld-eks-ingress-nginx-v2.zone_id
     evaluate_target_health = true
   }
 }


### PR DESCRIPTION
in https://gitlab.com/ucsb-library/cloud-infra/-/issues/69, we added a new NLB
as the preferred target for `dld-eks` cluster ingress. point all existing dns
records to this, instead of the old classic load balancer.