### PR TITLE
adding subdomain for avcollections

### DIFF
--- a/terraform/zones/zone.library.ucsb.edu.tf
+++ b/terraform/zones/zone.library.ucsb.edu.tf
@@ -1030,6 +1030,14 @@ zone_id = local.library-zone_id
   records = ["128.111.87.246"]
 }
 
+resource "aws_route53_record" "avcollections-library-ucsb-edu-CNAME" {
+zone_id = local.library-zone_id
+  name    = "avcollections.library.ucsb.edu."
+  type    = "CNAME"
+  ttl     = "10800"
+  records = ["ucsb.aviaryplatform.com."]
+}
+
 resource "aws_route53_record" "atempo-library-ucsb-edu-A" {
 zone_id = local.library-zone_id
   name    = "atempo.library.ucsb.edu."


### PR DESCRIPTION
Added CNAME per Aviary documentation for the custom URL. See https://ucsb-atlas.atlassian.net/browse/OPS-5077. Change already added to WinDNS. 