### PR TITLE
Cname validation for library.ucsb.edu wildcard acm cert

### DIFF
--- a/terraform/zones/s3-backend.tf
+++ b/terraform/zones/s3-backend.tf
@@ -4,6 +4,7 @@
 # https://github.com/cloudposse/terraform-aws-tfstate-backend#usage
 module "terraform_state_backend" {
   source                              = "cloudposse/tfstate-backend/aws"
+  version                             = "1.4.0"
   namespace                           = "ucsb-library"
   environment                         = "iac"
   stage                               = "terraform"

--- a/terraform/zones/zone.library.ucsb.edu.tf
+++ b/terraform/zones/zone.library.ucsb.edu.tf
@@ -30,6 +30,14 @@ zone_id = local.library-zone_id
   records = ["atlas-loadb-bxukailn7wf4-118553238.us-west-2.elb.amazonaws.com."]
 }
 
+resource "aws_route53_record" "*-library-ssl-renewal-automation" {
+zone_id = local.library-zone_id
+  name    = "_1a4ae0fdc09a2579501cceb77eff2835.library.ucsb.edu."
+  type    = "CNAME"
+  ttl     = "300"
+  records = ["_cecf8d1aea6148c752cdaeb6d9e6e16a.acm-validations.aws."]
+}
+
 resource "aws_route53_record" "we-remember-them-library-ucsb-edu-CNAME" {
 zone_id = local.library-zone_id
   name    = "we-remember-them.library.ucsb.edu."

--- a/terraform/zones/zone.library.ucsb.edu.tf
+++ b/terraform/zones/zone.library.ucsb.edu.tf
@@ -30,7 +30,7 @@ zone_id = local.library-zone_id
   records = ["atlas-loadb-bxukailn7wf4-118553238.us-west-2.elb.amazonaws.com."]
 }
 
-resource "aws_route53_record" "*-library-ssl-renewal-automation" {
+resource "aws_route53_record" "library-wildcard-ssl-renewal-automation" {
 zone_id = local.library-zone_id
   name    = "_1a4ae0fdc09a2579501cceb77eff2835.library.ucsb.edu."
   type    = "CNAME"


### PR DESCRIPTION
Added the CNAME DNS validation entry for the library.ucsb.edu wildcard ACM certificate in the library.ucsb.edu zone file.

Edited the s3-backend.tf to lock the use of the https://github.com/cloudposse/terraform-aws-tfstate-backend/releases provider to v1.4.0, as the updated to 1.4.1 (2 weeks ago) broke the init & plan.