### PR TITLE
Update zone.library.ucsb.edu.tf

### DIFF
--- a/terraform/zones/zone.library.ucsb.edu.tf
+++ b/terraform/zones/zone.library.ucsb.edu.tf
@@ -948,7 +948,7 @@ zone_id = local.library-zone_id
   name    = "avcollections.library.ucsb.edu."
   type    = "CNAME"
   ttl     = "10800"
-  records = ["ucsb.aviaryplatform.com."]
+  records = ["ucsblibrary.aviaryplatform.com."]
 }
 
 resource "aws_route53_record" "atempo-library-ucsb-edu-A" {


### PR DESCRIPTION
Changed the cname record for avcollections.library.ucsb.edu to point to ucsblibrary.aviaryplatform.com.