### PR TITLE
Update zone.library.ucsb.edu.tf

### DIFF
--- a/terraform/zones/zone.library.ucsb.edu.tf
+++ b/terraform/zones/zone.library.ucsb.edu.tf
@@ -720,7 +720,7 @@ zone_id = local.library-zone_id
   name    = "epm.library.ucsb.edu."
   type    = "CNAME"
   ttl     = "10800"
-  records = ["haproxy.library.ucsb.edu."]
+  records = ["proxyserver.ets.ucsb.edu."]
 }
 
 resource "aws_route53_record" "dfsRR-library-ucsb-edu-A" {


### PR DESCRIPTION
Change the epm.library.ucsb.edu CNAME from haproxy.library.ucsb.edu. to proxyserver.ets.ucsb.edu.