### PR TITLE
Update zone.library.ucsb.edu.tf

### DIFF
--- a/terraform/zones/zone.library.ucsb.edu.tf
+++ b/terraform/zones/zone.library.ucsb.edu.tf
@@ -625,9 +625,9 @@ zone_id = local.library-zone_id
 resource "aws_route53_record" "gateway-library-ucsb-edu-A" {
 zone_id = local.library-zone_id
   name    = "gateway.library.ucsb.edu."
-  type    = "A"
+  type    = "CNAME"
   ttl     = "300"
-  records = ["128.111.87.199"]
+  records = ["prod-p1p2-nlb1-b4daa64f1b2c25fc.elb.us-west-2.amazonaws.com."]
 }
 
 resource "aws_route53_record" "fridgemonitor-library-ucsb-edu-A" {


### PR DESCRIPTION
Changed the gateway.library.ucsb.edu record from an A Record to a CNAME and is now pointing to an NLB in the ITS INFR AWS account.