### PR TITLE
Update zone.library.ucsb.edu.tf

### DIFF
--- a/terraform/zones/zone.library.ucsb.edu.tf
+++ b/terraform/zones/zone.library.ucsb.edu.tf
@@ -638,6 +638,14 @@ zone_id = local.library-zone_id
   records = ["128.111.87.211"]
 }
 
+resource "aws_route53_record" "filemaker-lb-library-ucsb-edu-CNAME" {
+zone_id = local.library-zone_id
+  name    = "filemaker-lb.library.ucsb.edu."
+  type    = "CNAME"
+  ttl     = "300"
+  records = ["filemaker-2019.library.ucsb.edu."]
+}
+
 resource "aws_route53_record" "filemaker-library-ucsb-edu-CNAME" {
 zone_id = local.library-zone_id
   name    = "filemaker.library.ucsb.edu."


### PR DESCRIPTION
Added the filemaker-lb CNAME record that will eventually point to an NLB in front of the filemaker-2019 server.