### PR TITLE
Update zone.library.ucsb.edu.tf

### DIFF
--- a/terraform/zones/zone.library.ucsb.edu.tf
+++ b/terraform/zones/zone.library.ucsb.edu.tf
@@ -18,8 +18,8 @@ resource "aws_route53_record" "winshares-library-ucsb-edu-A" {
 zone_id = local.library-zone_id
   name    = "winshares.library.ucsb.edu."
   type    = "A"
-  ttl     = "10800"
-  records = ["128.111.87.95"]
+  ttl     = "300"
+  records = ["0.0.0.0"]
 }
 
 resource "aws_route53_record" "wiki-aws-library-ucsb-edu-CNAME" {


### PR DESCRIPTION
Changing the winshares A record to point to 0.0.0.0 to test to see if any workflows break ahead of the migration of the VM to AWS on Saturday 2026-05-09.